### PR TITLE
Laravel 5 isn't even supported anymore

### DIFF
--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -11,7 +11,10 @@ return [
     */
     'route' => [
         'prefix' => 'translations',
-        'middleware' => 'auth',
+        'middleware' => [
+            'web',
+            'auth'
+        ],
     ],
 
     /*

--- a/readme.md
+++ b/readme.md
@@ -58,32 +58,6 @@ composer require tanmuhittin/laravel-google-translate
 php artisan vendor:publish --provider=Tanmuhittin\LaravelGoogleTranslate\LaravelGoogleTranslateServiceProvider
  ```
 
-
-### Middleware / Auth
-
-The configuration file by default only includes the `auth` middleware, but the latests changes in Laravel 5.2 makes it that session variables are only accessible when your route includes the `web` middleware. In order to make this package work on Laravel 5.2, you will have to change the route/middleware setting from the default 
-
-```
-    'route' => [
-        'prefix' => 'translations',
-        'middleware' => 'auth',
-    ],
-```
-
-to
-
-```
-    'route' => [
-        'prefix' => 'translations',
-        'middleware' => [
-	        'web',
-	        'auth',
-		],
-    ],
-```
-
-**NOTE:** *This is only needed in Laravel 5.2 (and up!)*
-
 ## Usage
 
 ### Web interface


### PR DESCRIPTION
Laravel 5 isn't supported by neither Laravel itself or this package (according with `compose.json`). Why keep the default incompatible with the current version?