### PR TITLE
Remove double escaping

### DIFF
--- a/resources/views/bootstrap3/index.blade.php
+++ b/resources/views/bootstrap3/index.blade.php
@@ -149,7 +149,7 @@
                                        data-name="{{ $locale . "|" . htmlentities($key, ENT_QUOTES, 'UTF-8', false) }}"
                                        id="username" data-type="textarea" data-pk="{{ $t ? $t->id : 0 }}"
                                        data-url="{{ $editUrl }}"
-                                       data-title="Enter translation">{{ $t ? htmlentities($t->value, ENT_QUOTES, 'UTF-8', false) : '' }}</a>
+                                       data-title="Enter translation">{{ $t ? $t->value : '' }}</a>
                                 </td>
                             @endforeach
                             @if ($deleteEnabled)

--- a/resources/views/bootstrap4/blocks/_edit.blade.php
+++ b/resources/views/bootstrap4/blocks/_edit.blade.php
@@ -37,7 +37,7 @@
                                data-locale="{{$locale}}" data-name="{{ $locale }}|{{ $key }}"
                                id="username" data-type="textarea" data-pk="{{ $t ? $t->id : 0}}"
                                data-url="{{$editUrl}}"
-                               data-title="Enter translation">{{ $t ? htmlentities($t->value, ENT_QUOTES,  'UTF-8', false) : '' }}</a>
+                               data-title="Enter translation">{{ $t ? $t->value : '' }}</a>
                         </td>
                     @endforeach
                     @if ($deleteEnabled)

--- a/resources/views/bootstrap5/blocks/_edit.blade.php
+++ b/resources/views/bootstrap5/blocks/_edit.blade.php
@@ -36,7 +36,7 @@
                                data-locale="{{ $locale }}" data-name="{{ $locale }}|{{ $key }}"
                                id="username" data-type="textarea" data-pk="{{ $t ? $t->id : 0 }}"
                                data-url="{{ $editUrl }}"
-                               data-title="Enter translation">{{ $t ? htmlentities($t->value, ENT_QUOTES, 'UTF-8', false) : '' }}</a>
+                               data-title="Enter translation">{{ $t ? $t->value : '' }}</a>
                         </td>
                     @endforeach
                     @if ($deleteEnabled)

--- a/resources/views/tailwind3/blocks/_edit.blade.php
+++ b/resources/views/tailwind3/blocks/_edit.blade.php
@@ -35,7 +35,7 @@
                                    data-locale="{{ $locale }}" data-name="{{ $locale }}|{{ $key }}"
                                    id="username" data-type="textarea" data-pk="{{ $t ? $t->id : 0 }}"
                                    data-url="{{ $editUrl }}"
-                                   data-title="Enter translation">{{ $t ? htmlentities($t->value, ENT_QUOTES, 'UTF-8', false) : '' }}</a>
+                                   data-title="Enter translation">{{ $t ? $t->value : '' }}</a>
                             </td>
                         @endforeach
                         @if ($deleteEnabled)


### PR DESCRIPTION
Blade already does html escaping, by doing it twice strings like `Ação` where showing as `A&ccedil;&atilde;o`.