### PR TITLE
Changes and fixes related to database

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "php": ">=7.2",
     "illuminate/support": "^6|^7|^8|^9",
     "illuminate/translation": "^6|^7|^8|^9",
+    "illuminate/database": "^6|^7|^8|^9",
     "symfony/finder": "^4|^5|^6"
   },
   "require-dev": {

--- a/config/translation-manager.php
+++ b/config/translation-manager.php
@@ -37,7 +37,7 @@ return [
 
     'database' => [
         'table'         => env('TRANSLATION_TABLE_NAME', 'ltm_translations'),
-        'connection'    => env('TRANSLATION_CONNECTION', 'mysql'),
+        'connection'    => env('TRANSLATION_CONNECTION', env('DB_CONNECTION', 'system')),
     ],
 
     /**

--- a/database/migrations/2014_04_02_193005_create_translations_table.php
+++ b/database/migrations/2014_04_02_193005_create_translations_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 
 class CreateTranslationsTable extends Migration
 {
@@ -10,7 +11,7 @@ class CreateTranslationsTable extends Migration
      */
     public function up(): void
     {
-        Schema::create('ltm_translations', static function (Blueprint $table) {
+        Schema::create(config('translation-manager.database.table'), static function (Blueprint $table) {
             $table->collation = 'utf8mb4_bin';
             $table->bigIncrements('id');
             $table->integer('status')->default(0);
@@ -27,6 +28,6 @@ class CreateTranslationsTable extends Migration
      */
     public function down(): void
     {
-        Schema::drop('ltm_translations');
+        Schema::drop(config('translation-manager.database.table'));
     }
 }

--- a/src/Models/Translation.php
+++ b/src/Models/Translation.php
@@ -23,12 +23,9 @@ class Translation extends Model
     public const STATUS_SAVED = 0;
     public const STATUS_CHANGED = 1;
 
-    protected $table = 'ltm_translations';
-
-    protected $connection = 'mysql';
-
     public function __construct()
     {
+        parent::__construct();
         $this->connection = config('translation-manager.database.connection');
         $this->table = config('translation-manager.database.table');
     }


### PR DESCRIPTION
A few changes:

 1. Use the config values to create the table on migration
 2. Remove Translation model overriden properties and reintroduce parent constructor call.
 3. Use default Laravel connection by default instead of mysql