### PR TITLE
Export php files as most sane people would write them

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -281,6 +281,15 @@ class Manager
         }
     }
 
+    protected function export($expression, $return=FALSE) {
+        $export = var_export($expression, TRUE);
+        $export = preg_replace("/^([ ]*)(.*)/m", '$1$1$2', $export);
+        $array = preg_split("/\r\n|\n|\r/", $export);
+        $array = preg_replace(["/\s*array\s\($/", "/\)(,)?$/", "/\s=>\s$/"], [NULL, ']$1', ' => ['], $array);
+        $export = join(PHP_EOL, array_filter(["["] + $array));
+        if ((bool)$return) return $export; else echo $export;
+    }
+
     public function exportTranslations($group = null, $json = false): void
     {
         $group = basename($group);
@@ -329,7 +338,7 @@ class Manager
 
                         $path .= DIRECTORY_SEPARATOR.$locale.DIRECTORY_SEPARATOR.$group.'.php';
 
-                        $output = "<?php\n\nreturn ".var_export($translations, true).';'.\PHP_EOL;
+                        $output = "<?php\n\nreturn ".$this->export($translations, true).';'.\PHP_EOL;
                         $this->files->put($path, $output);
                     }
                 }


### PR DESCRIPTION
Instead of generating some pre-historic like arrays 
```php
return array (
  'a' => array (
    'key' => 'value'
  )
)
```
This custom method writes them as most people would:
```php
return [
  'a' => [
    'key' => 'value'
  ]
]
```