### PR TITLE
Fix issue of no persisted value for new translations

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -148,10 +148,10 @@ class Controller extends BaseController
                 $translation->locale = $locale;
                 $translation->group = $group;
                 $translation->key = $key;
-            } else {
-                $translation->value = (string) $value ?: null;
-                $translation->status = Translation::STATUS_CHANGED;
             }
+
+            $translation->value = (string) $value ?: null;
+            $translation->status = Translation::STATUS_CHANGED;
 
             $translation->save();
 


### PR DESCRIPTION
When creating a new language adding a translation for that translation would not persist the data if it's not already on the database.